### PR TITLE
Fix breadcrumb navigation redirect in AboutUs component

### DIFF
--- a/src/components/AboutUs.js
+++ b/src/components/AboutUs.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import "./AboutStyles.css"
 import banner from "../assets/63.jpg"
+import { Link } from "react-router-dom";
 
 function AboutUs() {
     return (
@@ -11,8 +12,7 @@ function AboutUs() {
             <div class="about-text">
                 <h1>About Us</h1>
                 <ul class="about-text-1">
-                    <li><a href="http://www.prachayikaevents.com/" className='Home-link'>Home</a></li>
-                    {/* <li>About</li> */}
+                    <li><Link to="/prachayika" className='Home-link'>Home</Link></li>
                 </ul>
             </div>
             <div className='container1'>


### PR DESCRIPTION
### Changes
- Replaced `<a href>` with `<Link>` from `react-router-dom`
- Updated Home route to point to `/prachayika` instead of external domain
- Ensured consistent internal SPA routing behavior

### Testing
1. Go to `/prachayika`
2. Navigate to the "About Us" page
3. Click the Home breadcrumb
4. Verify it returns to `/prachayika` without refresh or redirect

A little demonstration:


https://github.com/user-attachments/assets/6b59a4c1-f713-43c6-9dda-49354191a908


